### PR TITLE
[chore] Ensure accurate error reporting if beforeAll callback fails

### DIFF
--- a/.qawolf/responsive.test.ts
+++ b/.qawolf/responsive.test.ts
@@ -1,0 +1,52 @@
+import {Browser, BrowserContext} from 'playwright'
+import qawolf from 'qawolf'
+
+let browser: Browser | undefined
+let context: BrowserContext | undefined
+
+beforeAll(async () => {
+  browser = await qawolf.launch()
+  context = await browser.newContext()
+  await qawolf.register(context)
+})
+
+afterAll(async () => {
+  await qawolf.stopVideos()
+  await browser?.close()
+})
+
+describe('Responsive props', () => {
+  it('resizing window should hide and show responsive elements', async () => {
+    const page = await context!.newPage()
+
+    const url = 'http://localhost:9009/iframe.html?id=atoms-box--responsive&viewMode=story'
+
+    await page.goto(url, {waitUntil: 'domcontentloaded'})
+
+    const widthResponsivePropMap = {
+      320: 'none',
+      640: 'block',
+      960: 'none',
+      1280: 'block',
+      1600: 'none',
+      1920: 'block',
+    }
+
+    for (const width of Object.keys(widthResponsivePropMap)) {
+      await page.setViewportSize({width: Number(width) - 1, height: 1024})
+
+      const element = await page.$('#responsive-box')
+
+      if (!element) {
+        throw new Error('Expected test element to be found')
+      }
+
+      const display = await element.evaluate((uiElement) =>
+        getComputedStyle(uiElement).getPropertyValue('display')
+      )
+
+      // @ts-ignore
+      expect(display).toBe(widthResponsivePropMap[width])
+    }
+  })
+})

--- a/ui/src/components/autocomplete/autocomplete.qa.ts
+++ b/ui/src/components/autocomplete/autocomplete.qa.ts
@@ -1,8 +1,8 @@
 import {Browser, BrowserContext} from 'playwright'
 import qawolf from 'qawolf'
 
-let browser: Browser
-let context: BrowserContext
+let browser: Browser | undefined
+let context: BrowserContext | undefined
 
 beforeAll(async () => {
   browser = await qawolf.launch()
@@ -12,12 +12,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await qawolf.stopVideos()
-  await browser.close()
+  await browser?.close()
 })
 
 describe('Components/Autocomplete', () => {
   it('should use key arrows', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-autocomplete--custom&viewMode=story',
@@ -47,7 +48,8 @@ describe('Components/Autocomplete', () => {
   })
 
   it('should press clear button to clear', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-autocomplete--custom&viewMode=story',
@@ -78,7 +80,8 @@ describe('Components/Autocomplete', () => {
   })
 
   it('should collapse when tabbing out', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-autocomplete--custom&viewMode=story',

--- a/ui/src/components/dialog/dialog.qa.ts
+++ b/ui/src/components/dialog/dialog.qa.ts
@@ -1,8 +1,8 @@
 import {Browser, BrowserContext} from 'playwright'
 import qawolf from 'qawolf'
 
-let browser: Browser
-let context: BrowserContext
+let browser: Browser | undefined
+let context: BrowserContext | undefined
 
 beforeAll(async () => {
   browser = await qawolf.launch()
@@ -12,12 +12,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await qawolf.stopVideos()
-  await browser.close()
+  await browser?.close()
 })
 
 describe('Components/Dialog', () => {
   it('should open dialog', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-dialog--props&viewMode=story',
@@ -29,7 +30,8 @@ describe('Components/Dialog', () => {
   })
 
   it('should trap focus', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-dialog--props&viewMode=story',

--- a/ui/src/components/menu/menuButton.qa.ts
+++ b/ui/src/components/menu/menuButton.qa.ts
@@ -1,8 +1,8 @@
 import {Browser, BrowserContext} from 'playwright'
 import qawolf from 'qawolf'
 
-let browser: Browser
-let context: BrowserContext
+let browser: Browser | undefined
+let context: BrowserContext | undefined
 
 beforeAll(async () => {
   browser = await qawolf.launch()
@@ -12,12 +12,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await qawolf.stopVideos()
-  await browser.close()
+  await browser?.close()
 })
 
 describe('Components/MenuButton', () => {
   it('clicking should open/close menu', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-menu--menu-button&viewMode=story',
@@ -34,7 +35,8 @@ describe('Components/MenuButton', () => {
   })
 
   it('should use arrow keys to navigate the menu', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-menu--menu-button&viewMode=story',
@@ -76,7 +78,8 @@ describe('Components/MenuButton', () => {
   })
 
   it('should close on tab', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-menu--menu-button&viewMode=story',
@@ -95,7 +98,8 @@ describe('Components/MenuButton', () => {
   })
 
   it('should close on shift + tab', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-menu--menu-button&viewMode=story',
@@ -114,7 +118,8 @@ describe('Components/MenuButton', () => {
   })
 
   it('should not close when one of the items receives focus', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto(
       'http://localhost:9009/iframe.html?id=components-menu--menu-button&viewMode=story',

--- a/ui/src/components/tab/tab.qa.ts
+++ b/ui/src/components/tab/tab.qa.ts
@@ -1,8 +1,8 @@
 import {Browser, BrowserContext} from 'playwright'
 import qawolf from 'qawolf'
 
-let browser: Browser
-let context: BrowserContext
+let browser: Browser | undefined
+let context: BrowserContext | undefined
 
 beforeAll(async () => {
   browser = await qawolf.launch()
@@ -12,12 +12,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await qawolf.stopVideos()
-  await browser.close()
+  await browser?.close()
 })
 
 describe('Components/Tab', () => {
   it('should use keys to navigate tabs', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     await page.goto('http://localhost:9009/iframe.html?id=components-tab--example&viewMode=story', {
       waitUntil: 'domcontentloaded',

--- a/ui/src/primitives/box/box.qa.ts
+++ b/ui/src/primitives/box/box.qa.ts
@@ -1,8 +1,8 @@
 import {Browser, BrowserContext} from 'playwright'
 import qawolf from 'qawolf'
 
-let browser: Browser
-let context: BrowserContext
+let browser: Browser | undefined
+let context: BrowserContext | undefined
 
 beforeAll(async () => {
   browser = await qawolf.launch()
@@ -12,12 +12,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await qawolf.stopVideos()
-  await browser.close()
+  await browser?.close()
 })
 
 describe('Primitives/Box', () => {
   it('resizing window should hide and show responsive elements', async () => {
-    const page = await context.newPage()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const page = await context!.newPage()
 
     const url = 'http://localhost:9009/iframe.html?id=atoms-box--responsive&viewMode=story'
 


### PR DESCRIPTION
This fixes an issue that reported inaccurate error message if something failed during `beforeAll`: E.g. if launching `qawolf` in the `beforeAll`-callback failed, the `browser` variable would be undefined, which again would make the `afterAll` callback fail when it tried to call `close()` on it. This obscured the original error, and made jest report `TypeError: Cannot read property 'close' of undefined` as the error and not the original error that happened in the beforeAll`-callback.

Note: added a few non-null assertions in the actual tests, since we can be sure that the variables are initialized when if we get to actually running the test.