### PR TITLE
[ui] Add `textOverflow` property to Heading, Label and Text

### DIFF
--- a/ui/src/primitives/heading/heading.stories.tsx
+++ b/ui/src/primitives/heading/heading.stories.tsx
@@ -1,7 +1,7 @@
-import {Icon} from '@sanity/icons'
-import {Card, Heading, Inline} from '@sanity/ui'
-import {boolean, select, withKnobs} from '@storybook/addon-knobs'
+import {Card, Heading} from '@sanity/ui'
+import {boolean, select, text, withKnobs} from '@storybook/addon-knobs'
 import React from 'react'
+import {Container} from '../container'
 import {withCentered} from '~/storybook/decorators'
 
 export default {
@@ -16,28 +16,37 @@ export const plain = () => {
 
   const size = select('Size', {'0': 0, '1': 1, '2 (default)': 2, '3': 3, '4': 4}, 2, 'Props')
 
-  const weight = select(
-    'Weight',
-    {
-      'Regular (default)': undefined,
-      Medium: 'medium',
-      Semibold: 'semibold',
-      Bold: 'bold',
-    },
-    undefined,
-    'Props'
-  )
+  const textChild = text('Text', 'Hello, world', 'Props')
 
-  const textProps = {accent, muted, size, weight}
+  const textOverflow =
+    select('Text overflow', {None: '', Ellipsis: 'ellipsis'}, '', 'Props') || undefined
+
+  const weight =
+    select(
+      'Weight',
+      {
+        'Regular (default)': '',
+        Medium: 'medium',
+        Semibold: 'semibold',
+        Bold: 'bold',
+      },
+      '',
+      'Props'
+    ) || undefined
 
   return (
-    <Card>
-      <Inline space={3}>
-        <Heading {...textProps}>
-          <Icon symbol="ok-hand" />
+    <Container width={0}>
+      <Card padding={4}>
+        <Heading
+          accent={accent}
+          muted={muted}
+          size={size}
+          textOverflow={textOverflow}
+          weight={weight}
+        >
+          {textChild}
         </Heading>
-        <Heading {...textProps}>Hello, world</Heading>
-      </Inline>
-    </Card>
+      </Card>
+    </Container>
   )
 }

--- a/ui/src/primitives/heading/heading.tsx
+++ b/ui/src/primitives/heading/heading.tsx
@@ -17,6 +17,12 @@ export interface HeadingProps {
   as?: React.ElementType | keyof JSX.IntrinsicElements
   muted?: boolean
   size?: number | number[]
+  /**
+   * Controls how overflowing text is treated.
+   * Use `textOverflow="ellipsis"` to render text as a single line which is concatenated with a `…` symbol.
+   * @beta
+   */
+  textOverflow?: 'ellipsis'
   weight?: ThemeFontWeightKey
 }
 
@@ -24,9 +30,31 @@ const Root = styled.div<
   HeadingStyleProps & ResponsiveTextAlignStyleProps & ResponsiveFontStyleProps
 >(headingBaseStyle, responsiveTextAlignStyle, responsiveHeadingFont)
 
+const SpanWithTextOverflow = styled.span`
+  display: block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`
+
 export const Heading = forwardRef(
   (props: HeadingProps & Omit<React.HTMLProps<HTMLElement>, 'size'>, ref) => {
-    const {accent = false, align, children, muted = false, size = 2, weight, ...restProps} = props
+    const {
+      accent = false,
+      align,
+      children: childrenProp,
+      muted = false,
+      size = 2,
+      textOverflow,
+      weight,
+      ...restProps
+    } = props
+
+    let children = childrenProp
+
+    if (textOverflow === 'ellipsis') {
+      children = <SpanWithTextOverflow>{children}</SpanWithTextOverflow>
+    }
 
     return (
       <Root

--- a/ui/src/primitives/label/label.stories.tsx
+++ b/ui/src/primitives/label/label.stories.tsx
@@ -1,5 +1,5 @@
 import {Card, Container, Label} from '@sanity/ui'
-import {select, withKnobs} from '@storybook/addon-knobs'
+import {select, text, withKnobs} from '@storybook/addon-knobs'
 import React from 'react'
 import {withCentered} from '~/storybook/decorators'
 
@@ -16,6 +16,11 @@ export const plain = () => {
     'Props'
   )
 
+  const textChild = text('Text', 'Hello, world', 'Props')
+
+  const textOverflow =
+    select('Text overflow', {None: '', Ellipsis: 'ellipsis'}, '', 'Props') || undefined
+
   const weight = select(
     'Weight',
     {
@@ -30,15 +35,9 @@ export const plain = () => {
 
   return (
     <Container width={0}>
-      <Card>
-        <Label size={size} weight={weight}>
-          Hello, world
-        </Label>
-        <Label size={size} weight={weight}>
-          Hello, world
-        </Label>
-        <Label size={size} weight={weight}>
-          Hello, world
+      <Card padding={4}>
+        <Label size={size} textOverflow={textOverflow} weight={weight}>
+          {textChild}
         </Label>
       </Card>
     </Container>

--- a/ui/src/primitives/label/label.tsx
+++ b/ui/src/primitives/label/label.tsx
@@ -11,6 +11,12 @@ interface LabelProps {
   as?: React.ElementType | keyof JSX.IntrinsicElements
   muted?: boolean
   size?: number | number[]
+  /**
+   * Controls how overflowing text is treated.
+   * Use `textOverflow="ellipsis"` to render text as a single line which is concatenated with a `…` symbol.
+   * @beta
+   */
+  textOverflow?: 'ellipsis'
   weight?: ThemeFontWeightKey
 }
 
@@ -21,9 +27,31 @@ const Root = styled.div<{
   $size: number[]
 }>(responsiveLabelFont, responsiveTextAlignStyle, labelBaseStyle)
 
+const SpanWithTextOverflow = styled.span`
+  display: block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`
+
 export const Label = forwardRef(
   (props: LabelProps & Omit<React.HTMLProps<HTMLDivElement>, 'size'>, ref) => {
-    const {accent, align, children, muted = false, size = 2, weight, ...restProps} = props
+    const {
+      accent,
+      align,
+      children: childrenProp,
+      muted = false,
+      size = 2,
+      textOverflow,
+      weight,
+      ...restProps
+    } = props
+
+    let children = childrenProp
+
+    if (textOverflow === 'ellipsis') {
+      children = <SpanWithTextOverflow>{children}</SpanWithTextOverflow>
+    }
 
     return (
       <Root

--- a/ui/src/primitives/text/text.stories.tsx
+++ b/ui/src/primitives/text/text.stories.tsx
@@ -1,5 +1,5 @@
 import {Container, Text} from '@sanity/ui'
-import {boolean, select, withKnobs} from '@storybook/addon-knobs'
+import {boolean, select, text, withKnobs} from '@storybook/addon-knobs'
 import React from 'react'
 import {Card} from '../card'
 import {withCentered} from '~/storybook/decorators'
@@ -19,6 +19,11 @@ export const plain = () => {
 
   const size = select('Size', {'0': 0, '1': 1, '2 (default)': 2, '3': 3, '4': 4}, 2, 'Props')
 
+  const textChild = text('Text', 'Hello, world', 'Props')
+
+  const textOverflow =
+    select('Text overflow', {None: '', Ellipsis: 'ellipsis'}, '', 'Props') || undefined
+
   const weight = select(
     'Weight',
     {
@@ -31,12 +36,19 @@ export const plain = () => {
     'Props'
   )
 
-  const textProps = {accent, align, muted, size, weight}
-
   return (
     <Container width={0}>
-      <Card>
-        <Text {...textProps}>Hello, world</Text>
+      <Card padding={4}>
+        <Text
+          accent={accent}
+          align={align}
+          muted={muted}
+          size={size}
+          textOverflow={textOverflow}
+          weight={weight}
+        >
+          {textChild}
+        </Text>
       </Card>
     </Container>
   )

--- a/ui/src/primitives/text/text.tsx
+++ b/ui/src/primitives/text/text.tsx
@@ -15,6 +15,12 @@ export interface TextProps {
   as?: React.ElementType | keyof JSX.IntrinsicElements
   muted?: boolean
   size?: number | number[]
+  /**
+   * Controls how overflowing text is treated.
+   * Use `textOverflow="ellipsis"` to render text as a single line which is concatenated with a `…` symbol.
+   * @beta
+   */
+  textOverflow?: 'ellipsis'
   weight?: ThemeFontWeightKey
 }
 
@@ -24,9 +30,31 @@ const Root = styled.div<ResponsiveFontStyleProps>(
   textBaseStyle
 )
 
+const SpanWithTextOverflow = styled.span`
+  display: block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`
+
 export const Text = forwardRef(
   (props: TextProps & Omit<React.HTMLProps<HTMLDivElement>, 'size'>, ref) => {
-    const {accent = false, align, children, muted = false, size = 2, weight, ...restProps} = props
+    const {
+      accent = false,
+      align,
+      children: childrenProp,
+      muted = false,
+      size = 2,
+      textOverflow,
+      weight,
+      ...restProps
+    } = props
+
+    let children = childrenProp
+
+    if (textOverflow === 'ellipsis') {
+      children = <SpanWithTextOverflow>{children}</SpanWithTextOverflow>
+    }
 
     return (
       <Root


### PR DESCRIPTION
This change adds a `textOverflow` property to the typographic primitives `Heading`, `Label`, and `Text`. This means you can do the following to achieve a single line of text which is concatenated with `…`:

```jsx
<Text textOverflow="ellipsis">
  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
  labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
  laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
  voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
  non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
</Text>
```

Which will render:
![image](https://user-images.githubusercontent.com/406933/105744424-6231b280-5f3d-11eb-9cce-12461edbcdf9.png)
