### PR TITLE
[ui] Prevent Dialog from closing on click outside

### DIFF
--- a/ui/src/components/dialog/dialog.stories.tsx
+++ b/ui/src/components/dialog/dialog.stories.tsx
@@ -27,6 +27,8 @@ export default {
 export const props = () => {
   const header = text('Header', 'Props example', 'Props')
 
+  const onClickOutside = boolean('Close when click outside', false, 'Props')
+
   const width = select(
     'Width',
     {
@@ -44,7 +46,7 @@ export const props = () => {
 
   return (
     <LayerProvider>
-      <PropsExample header={header} width={width} />
+      <PropsExample header={header} onClickOutside={onClickOutside} width={width} />
     </LayerProvider>
   )
 }
@@ -120,7 +122,10 @@ export const position = () => {
   )
 }
 
-function PropsExample(props: Omit<DialogProps, 'id' | 'onClose'>) {
+function PropsExample(
+  props: Omit<DialogProps, 'id' | 'onClickOutside' | 'onClose'> & {onClickOutside: boolean}
+) {
+  const {onClickOutside, ...restProps} = props
   const [open, setOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement | null>(null)
 
@@ -139,7 +144,12 @@ function PropsExample(props: Omit<DialogProps, 'id' | 'onClose'>) {
       />
 
       {open && (
-        <Dialog {...props} id="dialog" onClose={handleClose}>
+        <Dialog
+          {...restProps}
+          id="dialog"
+          onClickOutside={onClickOutside ? handleClose : undefined}
+          onClose={handleClose}
+        >
           <Box padding={4}>
             <Stack space={4}>
               <Text>

--- a/ui/src/components/dialog/dialog.tsx
+++ b/ui/src/components/dialog/dialog.tsx
@@ -22,6 +22,7 @@ export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProp
   footer?: React.ReactNode
   header?: React.ReactNode
   id: string
+  onClickOutside?: () => void
   onClose?: () => void
   position?: DialogPosition | DialogPosition[]
   scheme?: ThemeColorSchemeKey
@@ -33,6 +34,7 @@ interface DialogCardProps extends ResponsiveWidthProps {
   footer: React.ReactNode
   header: React.ReactNode
   id: string
+  onClickOutside?: () => void
   onClose?: () => void
   radius: number | number[]
   scheme?: ThemeColorSchemeKey
@@ -96,7 +98,19 @@ const DialogFooter = styled(Box)`
 `
 
 const DialogCard = forwardRef((props: DialogCardProps, ref) => {
-  const {children, contentRef, footer, header, id, onClose, radius, scheme, shadow, width} = props
+  const {
+    children,
+    contentRef,
+    footer,
+    header,
+    id,
+    onClickOutside,
+    onClose,
+    radius,
+    scheme,
+    shadow,
+    width,
+  } = props
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
   const localContentRef = useRef<HTMLDivElement | null>(null)
   const layer = useLayer()
@@ -129,8 +143,11 @@ const DialogCard = forwardRef((props: DialogCardProps, ref) => {
   useClickOutside(
     useCallback(() => {
       if (!isTopLayer) return
-      if (onClose) onClose()
-    }, [isTopLayer, onClose]),
+
+      if (onClickOutside) {
+        onClickOutside()
+      }
+    }, [isTopLayer, onClickOutside]),
     [rootElement]
   )
 
@@ -201,6 +218,7 @@ export const Dialog = forwardRef(
       footer,
       header,
       id,
+      onClickOutside,
       onClose,
       padding = 4,
       position = 'fixed',
@@ -255,6 +273,7 @@ export const Dialog = forwardRef(
             footer={footer}
             header={header}
             id={id}
+            onClickOutside={onClickOutside}
             onClose={onClose}
             radius={cardRadius}
             ref={cardRef}


### PR DESCRIPTION
### Description

- This change introduces a new `onClickOutside` property to the `Dialog` component.
- This change is introduced because in some cases the click outside behavior must be optional.

### What to review

- Create a Dialog instance without a `onClickOutside` property and make sure the Dialog is not closed when clicking outside of the Dialog.
- Create a Dialog instance​ with a `onClickOutside` property and make sure the callback is called when clicking outside of the Dialog.

### Notes for release

- Adds a new `onClickOutside` property to `Dialog` for handling cases when there's need to trigger changes when clicking outside of the dialog.
**BREAKING CHANGE**: The `onClose` callback is no longer called when the user clicks outside of the `Dialog` component, since there's now a designated callback for that.