### PR TITLE
feat(ui): add support for responsive z-offsets and `DialogProvider` for defaults

### DIFF
--- a/.cypress/integration/ui/layer.spec.ts
+++ b/.cypress/integration/ui/layer.spec.ts
@@ -1,0 +1,23 @@
+context('Utils/Layer', () => {
+  it('should support responsize z-offset', async () => {
+    cy.visit('http://localhost:9009/iframe.html?id=utils-layer--responsive-z-offset&viewMode=story')
+
+    const sizes = [
+      {viewport: [320, 600], css: {zIndex: '1'}},
+      {viewport: [360, 600], css: {zIndex: '2'}},
+      {viewport: [600, 600], css: {zIndex: '3'}},
+      {viewport: [900, 600], css: {zIndex: '3'}},
+      {viewport: [1200, 600], css: {zIndex: '3'}},
+      {viewport: [1800, 600], css: {zIndex: '3'}},
+      {viewport: [2400, 600], css: {zIndex: '3'}},
+    ]
+
+    for (const size of sizes) {
+      const {css, viewport} = size
+
+      cy.viewport(viewport[0], viewport[1])
+
+      cy.get('#responsive-layer').should('have.attr', 'style', `z-index: ${css.zIndex};`)
+    }
+  })
+})

--- a/ui/src/components/dialog/dialog.stories.tsx
+++ b/ui/src/components/dialog/dialog.stories.tsx
@@ -6,6 +6,7 @@ import {
   Code,
   Dialog,
   DialogProps,
+  DialogProvider,
   Layer,
   LayerProvider,
   Menu,
@@ -94,12 +95,6 @@ export const layering = () => {
   )
 }
 
-function DebugLayer() {
-  const layer = useLayer()
-
-  return <Code language="json">{JSON.stringify(layer, null, 2)}</Code>
-}
-
 export const position = () => {
   const open = boolean('Open', true, 'Props')
   const position = select('Position', ['fixed', 'absolute'], 'fixed', 'Props')
@@ -123,6 +118,23 @@ export const position = () => {
       </Box>
     </Box>
   )
+}
+
+export const provider = () => {
+  return (
+    <DialogProvider position="absolute" zOffset={1000}>
+      <Dialog id="provider-example">
+        Hello
+        <Dialog id="nested-provider-example">Hello</Dialog>
+      </Dialog>
+    </DialogProvider>
+  )
+}
+
+function DebugLayer() {
+  const layer = useLayer()
+
+  return <Code language="json">{JSON.stringify(layer, null, 2)}</Code>
 }
 
 function PropsExample(

--- a/ui/src/components/dialog/dialog.tsx
+++ b/ui/src/components/dialog/dialog.tsx
@@ -26,7 +26,7 @@ export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProp
   onClose?: () => void
   position?: DialogPosition | DialogPosition[]
   scheme?: ThemeColorSchemeKey
-  zOffset?: number
+  zOffset?: number | number[]
 }
 
 interface DialogCardProps extends ResponsiveWidthProps {

--- a/ui/src/components/dialog/dialog.tsx
+++ b/ui/src/components/dialog/dialog.tsx
@@ -14,6 +14,7 @@ import {
   ResponsiveDialogPositionStyleProps,
 } from './styles'
 import {DialogPosition} from './types'
+import {useDialog} from './useDialog'
 
 export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProps {
   cardRadius?: number | number[]
@@ -218,6 +219,7 @@ export const Dialog = forwardRef(
     props: DialogProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'id' | 'width'>,
     ref: React.Ref<HTMLDivElement>
   ) => {
+    const dialog = useDialog()
     const {
       cardRadius = 3,
       cardShadow = 4,
@@ -229,9 +231,10 @@ export const Dialog = forwardRef(
       onClickOutside,
       onClose,
       padding = 4,
-      position = 'fixed',
+      position = dialog.position || 'fixed',
       scheme,
       width = 0,
+      zOffset = dialog.zOffset,
       ...restProps
     } = props
     const preDivRef = useRef<HTMLDivElement | null>(null)
@@ -274,6 +277,7 @@ export const Dialog = forwardRef(
           onFocus={handleFocus}
           ref={ref}
           role="dialog"
+          zOffset={zOffset}
         >
           <div ref={preDivRef} tabIndex={0} />
           <DialogCard

--- a/ui/src/components/dialog/dialogContext.ts
+++ b/ui/src/components/dialog/dialogContext.ts
@@ -1,0 +1,22 @@
+import {createContext} from 'react'
+import {globalScope} from '../../lib/globalScope'
+import {DialogPosition} from './types'
+
+/**
+ * This API might change. DO NOT USE IN PRODUCTION.
+ * @beta
+ */
+export interface DialogContextValue {
+  version: 0.0
+  position?: DialogPosition | DialogPosition[]
+  zOffset?: number | number[]
+}
+
+const key = Symbol.for('@sanity/ui/context/dialog')
+
+globalScope[key] = globalScope[key] || createContext<DialogContextValue>({version: 0.0})
+
+/**
+ * @internal
+ */
+export const DialogContext: React.Context<DialogContextValue> = globalScope[key]

--- a/ui/src/components/dialog/dialogProvider.tsx
+++ b/ui/src/components/dialog/dialogProvider.tsx
@@ -1,0 +1,28 @@
+import React, {useMemo} from 'react'
+import {DialogContext, DialogContextValue} from './dialogContext'
+import {DialogPosition} from './types'
+
+interface DialogProviderProps {
+  children?: React.ReactNode
+  position?: DialogPosition | DialogPosition[]
+  zOffset?: number | number[]
+}
+
+/**
+ * This API might change. DO NOT USE IN PRODUCTION.
+ * @beta
+ */
+export function DialogProvider(props: DialogProviderProps) {
+  const {children, position, zOffset} = props
+
+  const contextValue: DialogContextValue = useMemo(
+    () => ({
+      version: 0.0,
+      position,
+      zOffset,
+    }),
+    [position, zOffset]
+  )
+
+  return <DialogContext.Provider value={contextValue}>{children}</DialogContext.Provider>
+}

--- a/ui/src/components/dialog/index.ts
+++ b/ui/src/components/dialog/index.ts
@@ -1,1 +1,4 @@
 export * from './dialog'
+export * from './dialogContext'
+export * from './dialogProvider'
+export * from './types'

--- a/ui/src/components/dialog/useDialog.ts
+++ b/ui/src/components/dialog/useDialog.ts
@@ -1,0 +1,10 @@
+import {useContext} from 'react'
+import {DialogContext} from './dialogContext'
+
+/**
+ * This API might change. DO NOT USE IN PRODUCTION.
+ * @beta
+ */
+export function useDialog() {
+  return useContext(DialogContext)
+}

--- a/ui/src/components/toast/toastProvider.tsx
+++ b/ui/src/components/toast/toastProvider.tsx
@@ -20,7 +20,7 @@ interface ToastProviderProps {
   padding?: number | number[]
   paddingX?: number | number[]
   paddingY?: number | number[]
-  zOffset?: number
+  zOffset?: number | number[]
 }
 
 const Root = styled(Layer)`

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useClickOutside'
 export * from './useGlobalKeyDown'
+export * from './useMediaIndex'
 export * from './usePrefersDark'
 export * from './useForwardedRef'
 export * from './useCustomValidity'

--- a/ui/src/hooks/useMediaIndex.stories.tsx
+++ b/ui/src/hooks/useMediaIndex.stories.tsx
@@ -1,0 +1,18 @@
+import {withKnobs} from '@storybook/addon-knobs'
+import React from 'react'
+import {useMediaIndex} from './useMediaIndex'
+
+export default {
+  decorators: [withKnobs],
+  title: 'Hooks/useMediaIndex',
+}
+
+export const test = () => {
+  return <TestExample />
+}
+
+function TestExample() {
+  const mediaIndex = useMediaIndex()
+
+  return <div>{mediaIndex}</div>
+}

--- a/ui/src/hooks/useMediaIndex.ts
+++ b/ui/src/hooks/useMediaIndex.ts
@@ -1,0 +1,54 @@
+import {useEffect, useState} from 'react'
+import {useTheme} from '../theme'
+
+function _getMediaQuery(media: number[], index: number) {
+  return index === 0
+    ? `(max-width: ${media[index] - 1}px)`
+    : `screen and (min-width: ${media[index - 1]}px) and (max-width: ${media[index] - 1}px)`
+}
+
+/**
+ * This API might change. DO NOT USE IN PRODUCTION.
+ * @beta
+ */
+export function useMediaIndex() {
+  const theme = useTheme()
+  const {media} = theme.sanity
+
+  // Get initial index
+  const [index, setIndex] = useState(() => {
+    if (typeof window !== 'undefined') {
+      for (let idx = 0; idx < media.length; idx += 1) {
+        const mq = window.matchMedia(_getMediaQuery(media, idx))
+
+        if (mq.matches) {
+          return idx
+        }
+      }
+    }
+
+    return 0
+  })
+
+  useEffect(() => {
+    const disposeFns = media.map((_, idx) => {
+      const mq = window.matchMedia(_getMediaQuery(media, idx))
+
+      const handleChange = () => {
+        if (mq.matches) setIndex(idx)
+      }
+
+      mq.addEventListener('change', handleChange)
+
+      return () => {
+        mq.removeEventListener('change', handleChange)
+      }
+    })
+
+    return () => {
+      disposeFns.forEach((disposeFn) => disposeFn())
+    }
+  }, [media])
+
+  return index
+}

--- a/ui/src/utils/layer/layer.stories.tsx
+++ b/ui/src/utils/layer/layer.stories.tsx
@@ -73,6 +73,16 @@ export const multipleRoots = () => {
   )
 }
 
+export const responsiveZOffset = () => {
+  return (
+    <Layer id="responsive-layer" zOffset={[1, 2, 3]}>
+      <Card padding={3} shadow={1}>
+        <LayerDebugInfo />
+      </Card>
+    </Layer>
+  )
+}
+
 function LayerDebugInfo() {
   const layer = useLayer()
 

--- a/ui/src/utils/layer/layer.tsx
+++ b/ui/src/utils/layer/layer.tsx
@@ -6,7 +6,7 @@ import {useLayer} from './useLayer'
 
 export interface LayerProps {
   as?: React.ElementType | keyof JSX.IntrinsicElements
-  zOffset?: number
+  zOffset?: number | number[]
 }
 
 interface LayerChildrenProps {

--- a/ui/src/utils/layer/layerProvider.tsx
+++ b/ui/src/utils/layer/layerProvider.tsx
@@ -1,15 +1,19 @@
 import React, {useCallback, useContext, useEffect, useMemo, useState} from 'react'
+import {useMediaIndex, useResponsiveProp} from '../../hooks'
 import {LayerContext, LayerContextValue} from './layerContext'
 
 export function LayerProvider({
   children,
-  zOffset = 0,
+  zOffset: zOffsetProp = 0,
 }: {
   children?: React.ReactNode
-  zOffset?: number
+  zOffset?: number | number[]
 }) {
   const parent = useContext(LayerContext)
-  const zIndex = parent ? parent.zIndex + zOffset : zOffset
+  const zOffset = useResponsiveProp(zOffsetProp)
+  const maxMediaIndex = zOffset.length - 1
+  const mediaIndex = Math.min(useMediaIndex(), maxMediaIndex)
+  const zIndex = parent ? parent.zIndex + zOffset[mediaIndex] : zOffset[mediaIndex]
   const [size, setSize] = useState(0)
 
   const registerChild = useCallback(() => {


### PR DESCRIPTION
This change adds support for responsive z-offsets:

```tsx
// This layer will have z-index 0 on mobile, 1 on tablet, and 2 on desktop:
<Layer zOffset={[0, 10, 20]}>Test layer</Layer>
```

This change also introduces a new component called `DialogProvider` that can be used to provide default `zOffset` and `position` to nested `Dialog` components:

```tsx
<DialogProvider position="absolute" zOffset={100}>
  <Dialog id="dialog-a">This dialog will get z-index 100</Dialog>
  <Dialog id="dialog-a">This dialog will get z-index 100</Dialog>
</DialogProvider>
```
