### PR TITLE
fix(docs): add `shallow: true` to query changes in arcade

### DIFF
--- a/docs/screens/arcade/arcade.tsx
+++ b/docs/screens/arcade/arcade.tsx
@@ -29,7 +29,7 @@ export function ArcadeScreen(props: {title: string; description: string}) {
       replaceState({
         pathname: '/arcade',
         query: getArcadeQuery(params),
-      })
+      }, undefined, { shallow: true })
     }, 100)
 
     saveFnRef.current = saveFn

--- a/docs/screens/arcade/arcade.tsx
+++ b/docs/screens/arcade/arcade.tsx
@@ -26,10 +26,14 @@ export function ArcadeScreen(props: {title: string; description: string}) {
   // Create `saveFn` callback
   useEffect(() => {
     const saveFn = debounce((params: ArcadeQueryParams) => {
-      replaceState({
-        pathname: '/arcade',
-        query: getArcadeQuery(params),
-      }, undefined, { shallow: true })
+      replaceState(
+        {
+          pathname: '/arcade',
+          query: getArcadeQuery(params),
+        },
+        undefined,
+        {shallow: true}
+      )
     }, 100)
 
     saveFnRef.current = saveFn


### PR DESCRIPTION
I was playing around with the Arcade and noticed it fires requests at every keystroke. That's because the usage of Next's router.replace doesn't include a `shallow: true` option.

If we add that, Next won't try to query the backend every time the router changes, which will improve performance of the query encoding mechanism and save a lot of requests from being made. [More on Next's docs](https://nextjs.org/docs/routing/shallow-routing).