### PR TITLE
fix(ui): fix `useMediaIndex` browser support issue (Safari 13)

### DIFF
--- a/ui/src/hooks/useMediaIndex.ts
+++ b/ui/src/hooks/useMediaIndex.ts
@@ -38,10 +38,18 @@ export function useMediaIndex() {
         if (mq.matches) setIndex(idx)
       }
 
-      mq.addEventListener('change', handleChange)
+      if (mq.addEventListener) {
+        mq.addEventListener('change', handleChange)
+      } else {
+        mq.addListener(handleChange)
+      }
 
       return () => {
-        mq.removeEventListener('change', handleChange)
+        if (mq.removeEventListener) {
+          mq.removeEventListener('change', handleChange)
+        } else {
+          mq.removeListener(handleChange)
+        }
       }
     })
 


### PR DESCRIPTION
### Description

- Adds support for older mediaQuery syntax
- Fixes https://github.com/sanity-io/design/issues/566

### What to review

I tested this in the local storybook with `dev:ui`. When viewing the `useMediaIndex` entry, it was initially broken, but this change fixed it.

I'm unable to test in my local studio (using `yarn link @sanity/ui`) because of some Styled Components issues.

### Notes for release

- Adds support for Safari 13
