### PR TITLE
Fix size and position of readOnlyIcon

### DIFF
--- a/packages/@sanity/icons/src/icons/readOnlyIcon.tsx
+++ b/packages/@sanity/icons/src/icons/readOnlyIcon.tsx
@@ -10,7 +10,7 @@ function ReadOnlyIcon(props: React.SVGProps<SVGSVGElement>, svgRef?: React.Ref<S
       data-sanity-icon="read-only"
       width="1em"
       height="1em"
-      viewBox="0 0 17 16"
+      viewBox="-3 -5 20 25"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       ref={svgRef}


### PR DESCRIPTION
### Description

Fixes ReadOnlyIcon, which renders larger than the other icons.

### What to review

There may be a better approach, such as fixing the path.

### Notes for release

- Fixes the size of ReadOnlyIcon.
