### PR TITLE
feat(ui): add option to hide `Dialog` close button

### DIFF
--- a/packages/@sanity/ui/src/components/dialog/dialog.tsx
+++ b/packages/@sanity/ui/src/components/dialog/dialog.tsx
@@ -24,12 +24,15 @@ export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProp
    * @beta
    */
   __unstable_autoFocus?: boolean
+  /**
+   * @beta
+   */
+  __unstable_hideCloseButton?: boolean
   cardRadius?: number | number[]
   cardShadow?: number | number[]
   contentRef?: React.ForwardedRef<HTMLDivElement>
   footer?: React.ReactNode
   header?: React.ReactNode
-  hideCloseButton?: boolean
   id: string
   onClickOutside?: () => void
   onClose?: () => void
@@ -42,12 +45,15 @@ interface DialogCardProps extends ResponsiveWidthProps {
   /**
    * @beta
    */
-  __unstable_autoFocus?: boolean
+  __unstable_autoFocus: boolean
+  /**
+   * @beta
+   */
+  __unstable_hideCloseButton: boolean
   children: React.ReactNode
   contentRef?: React.ForwardedRef<HTMLDivElement>
   footer: React.ReactNode
   header: React.ReactNode
-  hideCloseButton?: boolean
   id: string
   onClickOutside?: () => void
   onClose?: () => void
@@ -119,12 +125,12 @@ const DialogFooter = styled(Box)`
 
 const DialogCard = forwardRef(function DialogCard(props: DialogCardProps, ref) {
   const {
-    __unstable_autoFocus: autoFocus = true,
+    __unstable_autoFocus: autoFocus,
+    __unstable_hideCloseButton: hideCloseButton,
     children,
     contentRef,
     footer,
     header,
-    hideCloseButton = false,
     id,
     onClickOutside,
     onClose,
@@ -137,9 +143,8 @@ const DialogCard = forwardRef(function DialogCard(props: DialogCardProps, ref) {
   const localContentRef = useRef<HTMLDivElement | null>(null)
   const layer = useLayer()
   const {isTopLayer} = layer
-
   const labelId = `${id}_label`
-  const showCloseButton = !hideCloseButton && onClose
+  const showCloseButton = !hideCloseButton && Boolean(onClose)
 
   useEffect(() => {
     if (!autoFocus) return
@@ -243,13 +248,13 @@ export const Dialog = forwardRef(function Dialog(
   const theme = useTheme()
   const {
     __unstable_autoFocus: autoFocus = true,
+    __unstable_hideCloseButton: hideCloseButton = false,
     cardRadius = 3,
     cardShadow = 4,
     children,
     contentRef,
     footer,
     header,
-    hideCloseButton = false,
     id,
     onClickOutside,
     onClose,
@@ -305,10 +310,10 @@ export const Dialog = forwardRef(function Dialog(
         <div ref={preDivRef} tabIndex={0} />
         <DialogCard
           __unstable_autoFocus={autoFocus}
+          __unstable_hideCloseButton={hideCloseButton}
           contentRef={contentRef}
           footer={footer}
           header={header}
-          hideCloseButton={hideCloseButton}
           id={id}
           onClickOutside={onClickOutside}
           onClose={onClose}

--- a/packages/@sanity/ui/src/components/dialog/dialog.tsx
+++ b/packages/@sanity/ui/src/components/dialog/dialog.tsx
@@ -29,6 +29,7 @@ export interface DialogProps extends ResponsivePaddingProps, ResponsiveWidthProp
   contentRef?: React.ForwardedRef<HTMLDivElement>
   footer?: React.ReactNode
   header?: React.ReactNode
+  hideCloseButton?: boolean
   id: string
   onClickOutside?: () => void
   onClose?: () => void
@@ -46,6 +47,7 @@ interface DialogCardProps extends ResponsiveWidthProps {
   contentRef?: React.ForwardedRef<HTMLDivElement>
   footer: React.ReactNode
   header: React.ReactNode
+  hideCloseButton?: boolean
   id: string
   onClickOutside?: () => void
   onClose?: () => void
@@ -122,6 +124,7 @@ const DialogCard = forwardRef(function DialogCard(props: DialogCardProps, ref) {
     contentRef,
     footer,
     header,
+    hideCloseButton = false,
     id,
     onClickOutside,
     onClose,
@@ -136,6 +139,7 @@ const DialogCard = forwardRef(function DialogCard(props: DialogCardProps, ref) {
   const {isTopLayer} = layer
 
   const labelId = `${id}_label`
+  const showCloseButton = !hideCloseButton && onClose
 
   useEffect(() => {
     if (!autoFocus) return
@@ -203,15 +207,17 @@ const DialogCard = forwardRef(function DialogCard(props: DialogCardProps, ref) {
                   </Text>
                 )}
               </Box>
-              <Box padding={2}>
-                <Button
-                  aria-label="Close dialog"
-                  icon={CloseIcon}
-                  mode="bleed"
-                  onClick={onClose}
-                  padding={3}
-                />
-              </Box>
+              {showCloseButton && (
+                <Box padding={2}>
+                  <Button
+                    aria-label="Close dialog"
+                    icon={CloseIcon}
+                    mode="bleed"
+                    onClick={onClose}
+                    padding={3}
+                  />
+                </Box>
+              )}
             </Flex>
           </DialogHeader>
 
@@ -243,6 +249,7 @@ export const Dialog = forwardRef(function Dialog(
     contentRef,
     footer,
     header,
+    hideCloseButton = false,
     id,
     onClickOutside,
     onClose,
@@ -301,6 +308,7 @@ export const Dialog = forwardRef(function Dialog(
           contentRef={contentRef}
           footer={footer}
           header={header}
+          hideCloseButton={hideCloseButton}
           id={id}
           onClickOutside={onClickOutside}
           onClose={onClose}

--- a/packages/@sanity/ui/src/components/dialog/dialog.workshop.tsx
+++ b/packages/@sanity/ui/src/components/dialog/dialog.workshop.tsx
@@ -53,6 +53,7 @@ function DebugLayer() {
 function PropsStory() {
   const header = useText('Header', 'Props example', 'Props')
   const onClickOutside = useBoolean('Close when click outside', false, 'Props') || false
+  const hideCloseButton = useBoolean('Hide close button', false, 'Props') || false
   const width = useSelect('Width', WIDTH_OPTIONS, 0, 'Props')
   const [open, setOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement | null>(null)
@@ -80,6 +81,7 @@ function PropsStory() {
             onClose={handleClose}
             open={open}
             width={width}
+            hideCloseButton={hideCloseButton}
           >
             <Box padding={4}>
               <Stack space={4}>

--- a/packages/@sanity/ui/src/components/dialog/dialog.workshop.tsx
+++ b/packages/@sanity/ui/src/components/dialog/dialog.workshop.tsx
@@ -75,13 +75,13 @@ function PropsStory() {
 
         {open && (
           <Dialog
+            __unstable_hideCloseButton={hideCloseButton}
             header={header}
             id="dialog"
             onClickOutside={onClickOutside ? handleClose : undefined}
             onClose={handleClose}
             open={open}
             width={width}
-            hideCloseButton={hideCloseButton}
           >
             <Box padding={4}>
               <Stack space={4}>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
This update is introduced as we have encountered situations in the studio where we need to hide the close button.

- Adds a `__unstable_hideCloseButton` prop to the `Dialog`.
- Conditionally renders close button depending on the `__unstable_hideCloseButton` value, and whether `onClose` is passed or not.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

If `onClose` is passed and `__unstable_hideCloseButton` is `true`, the close button should not be rendered.

```
 <Dialog onClose={handleClose} __unstable_hideCloseButton>
    {/* content */}
 </Dialog>
```

If `onClick` is not passed, the close button should not be rendered.

```
 <Dialog>
    {/* content */}
 </Dialog>
```

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Add `__unstable_hideCloseButton` property to `Dialog` to hide close button

