### PR TITLE
fix(ui): focus the first focusable element in dialogs

### DIFF
--- a/.cypress/integration/ui/dialog.spec.ts
+++ b/.cypress/integration/ui/dialog.spec.ts
@@ -15,9 +15,11 @@ context('Components/Dialog', () => {
     cy.get('#dialog').should('be.visible')
 
     // The first button should be focused
-    cy.get('#button-1').should('be.focused')
+    cy.get('#dialog button[aria-label="Close dialog"]').should('be.focused')
 
     // Tab to next until the focus is back at the top
+    cy.get('#dialog button[aria-label="Close dialog"]').realPress('Tab')
+    cy.get('#button-1').should('be.focused')
     cy.get('#button-1').realPress('Tab')
     cy.get('#button-2').should('be.focused')
     cy.get('#button-2').realPress('Tab')
@@ -27,8 +29,8 @@ context('Components/Dialog', () => {
     cy.get('#button-4').realPress('Tab')
     cy.get('#button-5').should('be.focused')
     cy.get('#button-5').realPress('Tab')
-    cy.get('button[aria-label="Close dialog"]').should('be.focused')
-    cy.get('button[aria-label="Close dialog"]').realPress('Tab')
+    cy.get('#dialog button[aria-label="Close dialog"]').should('be.focused')
+    cy.get('#dialog button[aria-label="Close dialog"]').realPress('Tab')
 
     // The first button should again be focused
     cy.get('#button-1').should('be.focused')

--- a/packages/@sanity/ui/src/components/dialog/__workshop__/autoFocus.tsx
+++ b/packages/@sanity/ui/src/components/dialog/__workshop__/autoFocus.tsx
@@ -1,10 +1,11 @@
 import {Box, Button, Dialog, Text} from '@sanity/ui'
-import {useBoolean} from '@sanity/ui-workshop'
+import {useAction, useBoolean} from '@sanity/ui-workshop'
 import React from 'react'
 
 export default function AutoFocusStory() {
   const autoFocus = useBoolean('Auto-focus', true, 'Props')
   const open = useBoolean('Open', false, 'Props')
+  const handleClose = useAction('onClose')
 
   if (!open) {
     return (
@@ -15,7 +16,12 @@ export default function AutoFocusStory() {
   }
 
   return (
-    <Dialog __unstable_autoFocus={autoFocus} header="Auto-focus example" id="auto-focus-example">
+    <Dialog
+      __unstable_autoFocus={autoFocus}
+      header="Auto-focus example"
+      id="auto-focus-example"
+      onClose={handleClose}
+    >
       <Box padding={4}>
         <Button text="Focusable button" />
       </Box>

--- a/packages/@sanity/ui/src/components/dialog/dialog.tsx
+++ b/packages/@sanity/ui/src/components/dialog/dialog.tsx
@@ -2,7 +2,7 @@ import {CloseIcon} from '@sanity/icons'
 import React, {forwardRef, useCallback, useEffect, useRef, useState} from 'react'
 import styled from 'styled-components'
 import {focusFirstDescendant, focusLastDescendant} from '../../helpers'
-import {useClickOutside, useGlobalKeyDown} from '../../hooks'
+import {useClickOutside, useForwardedRef, useGlobalKeyDown} from '../../hooks'
 import {Box, Button, Card, Container, Flex, Text} from '../../primitives'
 import {ResponsivePaddingProps, ResponsiveWidthProps} from '../../primitives/types'
 import {responsivePaddingStyle, ResponsivePaddingStyleProps} from '../../styles/internal'
@@ -123,7 +123,10 @@ const DialogFooter = styled(Box)`
   border-top: 1px solid var(--card-hairline-soft-color);
 `
 
-const DialogCard = forwardRef(function DialogCard(props: DialogCardProps, ref) {
+const DialogCard = forwardRef(function DialogCard(
+  props: DialogCardProps,
+  ref: React.ForwardedRef<HTMLDivElement>
+) {
   const {
     __unstable_autoFocus: autoFocus,
     __unstable_hideCloseButton: hideCloseButton,
@@ -139,6 +142,7 @@ const DialogCard = forwardRef(function DialogCard(props: DialogCardProps, ref) {
     shadow,
     width,
   } = props
+  const forwardedRef = useForwardedRef(ref)
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
   const localContentRef = useRef<HTMLDivElement | null>(null)
   const layer = useLayer()
@@ -151,10 +155,10 @@ const DialogCard = forwardRef(function DialogCard(props: DialogCardProps, ref) {
     if (!autoFocus) return
 
     // On mount: focus the first interactive element in the contents
-    if (localContentRef.current) {
-      focusFirstDescendant(localContentRef.current)
+    if (forwardedRef.current) {
+      focusFirstDescendant(forwardedRef.current)
     }
-  }, [autoFocus])
+  }, [autoFocus, forwardedRef])
 
   useGlobalKeyDown(
     useCallback(
@@ -183,10 +187,9 @@ const DialogCard = forwardRef(function DialogCard(props: DialogCardProps, ref) {
   const setRef = useCallback(
     (el: HTMLDivElement | null) => {
       setRootElement(el)
-      if (typeof ref === 'function') ref(el)
-      else if (ref) ref.current = el
+      forwardedRef.current = el
     },
-    [ref]
+    [forwardedRef]
   )
 
   const setContentRef = useCallback(


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This change fixes an issue which was caused by not including the dialog header as a container of focusable elements within dialogs. Closes #967.