### PR TITLE
feat(docs): add suppport for styled-components in arcade

### DIFF
--- a/apps/docs/components/article/articleContent/blocks/codeExample/codeExample.tsx
+++ b/apps/docs/components/article/articleContent/blocks/codeExample/codeExample.tsx
@@ -4,6 +4,7 @@ import * as ui from '@sanity/ui'
 import {Box, Button, Card, Flex, Spinner, Tab, TabList, TabPanel, Text} from '@sanity/ui'
 import Link from 'next/link'
 import React, {useCallback, useEffect, useState} from 'react'
+import styled, {keyframes} from 'styled-components'
 import {
   AsyncCodeEditor,
   Canvas,
@@ -35,7 +36,13 @@ export function CodeExample(props: {
   useEffect(() => {
     if (!ready) return
 
-    setEvalResult(evalComponent({hookCode, jsxCode, scope: {...icons, ...ui, ...React, React}}))
+    setEvalResult(
+      evalComponent({
+        hookCode,
+        jsxCode,
+        scope: {...icons, ...ui, ...React, React, styled, keyframes},
+      })
+    )
   }, [hookCode, jsxCode, ready])
 
   useEffect(() => {

--- a/apps/docs/pages/arcade-frame.tsx
+++ b/apps/docs/pages/arcade-frame.tsx
@@ -2,6 +2,7 @@ import * as icons from '@sanity/icons'
 import * as ui from '@sanity/ui'
 import {Card, Code, ErrorBoundary, Text} from '@sanity/ui'
 import React, {useCallback, useEffect, useState} from 'react'
+import styled, {keyframes} from 'styled-components'
 import {useApp} from '$components/app'
 import {evalComponent, EvalComponentResult, ready as readyCheck} from '$lib/ide'
 import {isRecord} from '$lib/types'
@@ -47,7 +48,13 @@ export default function ArcadeFrame() {
     if (hookCode === null) return
     if (jsxCode === null) return
 
-    setEvalResult(evalComponent({hookCode, jsxCode, scope: {...icons, ...ui, ...React, React}}))
+    setEvalResult(
+      evalComponent({
+        hookCode,
+        jsxCode,
+        scope: {...icons, ...ui, ...React, React, styled, keyframes},
+      })
+    )
   }, [hookCode, jsxCode, evalReady])
 
   useEffect(() => {


### PR DESCRIPTION
### Description

This adds support for styled-components in Arcade, inside of the Hook tab.

![image](https://user-images.githubusercontent.com/10508/139440581-0de95fca-a0fc-4b52-a056-10b3f87a5708.png)
![image](https://user-images.githubusercontent.com/10508/139440537-6f195db1-1eb0-4e1d-a7d0-14bc129c8a29.png)

### What to review

What should we call the Hook tab since it is the functional component's scope?

### Notes for release

- Add support of styled-components 
