### PR TITLE
fix(MenuItem): add data-disabled to MenuItem when it is disabled

### DIFF
--- a/packages/@sanity/ui/src/components/menu/menuItem.tsx
+++ b/packages/@sanity/ui/src/components/menu/menuItem.tsx
@@ -111,6 +111,7 @@ export const MenuItem = forwardRef(function MenuItem(
       aria-pressed={as === 'button' && pressed}
       data-pressed={as !== 'button' && pressed ? '' : undefined}
       data-selected={selected ? '' : undefined}
+      data-disabled={disabled ? '' : undefined}
       $radius={radius}
       $tone={tone}
       disabled={disabled}


### PR DESCRIPTION
### Description

Fixes issue where when using the MenuItem as an anchor wasn't giving the right style

### What to review

Changing any of the MenuItem examples to be `as="a"` and making it disabled, before the fix, shows that while it is disabled the styles do not reflect that.

### Notes for release

Fix visual bug when a disabled MenuItem was used as an anchor
