### PR TITLE
refactor(ui): use simpler `isEqual` for `useUnique` hook

### DIFF
--- a/apps/docs/lib/nav/nav.ts
+++ b/apps/docs/lib/nav/nav.ts
@@ -1,4 +1,3 @@
-import {uniq} from 'lodash'
 import {NavItem, NavMenu, NavMenuItem} from './types'
 import {features} from '$config'
 import {isArray, isRecord, isString} from '$lib/types'
@@ -122,4 +121,8 @@ export function buildNavMenu(navItem: NavItem): NavMenu {
     collapsed: false,
     items,
   }
+}
+
+function uniq(items: string[]): string[] {
+  return items.filter((item, index) => items.indexOf(item) === index)
 }

--- a/apps/docs/lib/page/_global/loadGlobalPageData.ts
+++ b/apps/docs/lib/page/_global/loadGlobalPageData.ts
@@ -1,4 +1,3 @@
-import {isArray} from 'lodash'
 import {DATA_QUERY} from './queries'
 import {buildNavMenu, findNavNode, getNavItems} from '$lib/nav'
 import {isRecord} from '$lib/types'
@@ -16,7 +15,7 @@ export async function loadGlobalPageData({
   const pageData: unknown = await getClient(preview).fetch(DATA_QUERY)
   const nav = isRecord(pageData) && pageData.nav
   const settings = isRecord(pageData) && pageData.settings
-  const navValues: unknown[] = (isRecord(nav) && isArray(nav.items) && nav.items) || []
+  const navValues: unknown[] = (isRecord(nav) && Array.isArray(nav.items) && nav.items) || []
   const node = findNavNode(navValues, path)
   const targetData: unknown = await getClient(preview).fetch(TARGET_QUERY, {
     id: node ? node.targetId : '404',

--- a/apps/docs/lib/page/docs/loadDocsPageData.ts
+++ b/apps/docs/lib/page/docs/loadDocsPageData.ts
@@ -1,4 +1,3 @@
-import {isArray} from 'lodash'
 import {DATA_QUERY} from './queries'
 import {buildNavMenu, findNavNode, getNavItems} from '$lib/nav'
 import {isRecord} from '$lib/types'
@@ -16,7 +15,7 @@ export async function loadDocsPageData({
   const pageData: unknown = await getClient(preview).fetch(DATA_QUERY)
   const nav = isRecord(pageData) && pageData.nav
   const settings = isRecord(pageData) && pageData.settings
-  const navValues: unknown[] = (isRecord(nav) && isArray(nav.items) && nav.items) || []
+  const navValues: unknown[] = (isRecord(nav) && Array.isArray(nav.items) && nav.items) || []
   const node = findNavNode(navValues, path)
   const targetData: unknown = await getClient(preview).fetch(TARGET_QUERY, {
     id: node ? node.targetId : '404',

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,7 +26,7 @@
     "@sanity/ui-workshop": "^0.3.12",
     "codemirror": "^5.65.1",
     "date-fns": "^2.28.0",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "next": "^12.0.8",
     "next-sanity": "^0.4.0",
     "pako": "^2.0.4",
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@types/codemirror": "^5.60.5",
+    "@types/lodash-es": "^4.17.5",
     "@types/pako": "^1.0.3",
     "@types/qs": "^6.9.7",
     "babel-plugin-styled-components": "^2.0.2",

--- a/apps/docs/screens/arcade/arcade.tsx
+++ b/apps/docs/screens/arcade/arcade.tsx
@@ -1,5 +1,5 @@
 import {Card, Flex} from '@sanity/ui'
-import {debounce, DebouncedFunc} from 'lodash'
+import {debounce, DebouncedFunc} from 'lodash-es'
 import Head from 'next/head'
 import {useRouter} from 'next/router'
 import qs from 'qs'

--- a/packages/@sanity/ui/package.json
+++ b/packages/@sanity/ui/package.json
@@ -34,7 +34,6 @@
     "@sanity/color": "^2.1.6",
     "@sanity/icons": "^1.2.3",
     "framer-motion": "6.2.1",
-    "lodash": "^4.17.21",
     "popper-max-size-modifier": "^0.2.0",
     "react-is": "^17.0.2",
     "react-popper": "^2.2.5",

--- a/packages/@sanity/ui/src/hooks/_internal/useUnique.ts
+++ b/packages/@sanity/ui/src/hooks/_internal/useUnique.ts
@@ -1,13 +1,15 @@
-import {isEqual} from 'lodash'
 import {useRef} from 'react'
 
 /**
- * This is React hook – an and escape hatch – to make sure that a value is the same
- * on every render. SHOULD NOT BE USED IN MOST CASES.
+ * This is a React hook – and an escape hatch – to make sure that a record is
+ * the same on every render. Uses strict equality comparison (eg by identity),
+ * and only goes one level deep. SHOULD NOT BE USED IN MOST CASES.
  *
  * @internal
  */
-export function useUnique<ValueType>(value: ValueType): ValueType {
+type Comparable = Record<string | number | symbol, unknown> | undefined | null
+
+export function useUnique<ValueType extends Comparable = Comparable>(value: ValueType): ValueType {
   const valueRef = useRef<ValueType>(value)
 
   if (!isEqual(valueRef.current, value)) {
@@ -15,4 +17,19 @@ export function useUnique<ValueType>(value: ValueType): ValueType {
   }
 
   return valueRef.current
+}
+
+function isEqual(objA: Comparable, objB: Comparable): boolean {
+  if (!objA || !objB) {
+    return objA === objB
+  }
+
+  const keysA = Object.keys(objA)
+  const keysB = Object.keys(objB)
+
+  if (keysA.length !== keysB.length) {
+    return false
+  }
+
+  return keysA.every((key) => objA[key] === objB[key])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4643,6 +4643,18 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash-es@^4.17.5":
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.5.tgz#1c3fdd16849d84aea43890b1c60da379fb501353"
+  integrity sha512-SHBoI8/0aoMQWAgUHMQ599VM6ZiSKg8sh/0cFqqlQQMyY9uEplc0ULU5yQNzcvdR4ZKa0ey8+vFmahuRbOCT1A==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.178"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
+  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+
 "@types/lodash@^4.14.149":
   version "4.14.172"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
@@ -13017,6 +13029,11 @@ lockfile@1.0.4:
   integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
   dependencies:
     signal-exit "^3.0.2"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash._arrayeach@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Description

This PR drops the use of `lodash` in `@sanity/ui`, since it was only used for `isEqual` in one place for a very specific use case with the portal implementation, where the comparison was a record of DOM elements - these can be triple-equally checked instead.

This cuts the bundle size for anyone using `@sanity/ui`.

I also took a stab at removing it from the rest of the repo, but stopped when I found `debounce` being used. It's not critical that we replace it in every instance, but it does add a bit of weight. To help tree shaking, I replaced `lodash` with `lodash-es` in the `docs` app.

### What to review

- That the changes makes sense and does not have any outside impact I am unaware of

### Notes for release

- Removed `lodash` as a dependency