### PR TITLE
feat(ui-workshop): add open story in new window 

### DIFF
--- a/packages/@sanity/ui-workshop/src/main/workshopNavbar.tsx
+++ b/packages/@sanity/ui-workshop/src/main/workshopNavbar.tsx
@@ -1,4 +1,4 @@
-import {ControlsIcon, MenuIcon, MoonIcon, SelectIcon, SunIcon} from '@sanity/icons'
+import {ControlsIcon, LaunchIcon, MenuIcon, MoonIcon, SelectIcon, SunIcon} from '@sanity/icons'
 import {
   Box,
   Breadcrumbs,
@@ -14,6 +14,7 @@ import {
 } from '@sanity/ui'
 import React, {useCallback, useMemo} from 'react'
 import styled from 'styled-components'
+import {useScope} from '../useScope'
 import {useWorkshop} from '../useWorkshop'
 import {VIEWPORT_OPTIONS, ZOOM_OPTIONS} from './constants'
 
@@ -30,8 +31,16 @@ export function WorkshopNavbar(props: {
   zoom: number
 }): React.ReactElement {
   const {scheme, setScheme, setViewport, setZoom, viewport, zoom} = props
-  const {pushLocation, scope, story, title} = useWorkshop()
+  const {pushLocation, scope, story, title, location, frameUrl} = useWorkshop()
+  const {value} = useScope()
 
+  const currentFrameUrl = useMemo(
+    () =>
+      `${frameUrl}?path=${location.path}&scheme=${scheme}&value=${encodeURIComponent(
+        JSON.stringify(value)
+      )}`,
+    [frameUrl, location.path, scheme, value]
+  )
   const handleToggleScheme = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const target = event.currentTarget
@@ -160,7 +169,21 @@ export function WorkshopNavbar(props: {
                   />
                 </LayerProvider>
               </Flex>
-
+              {story && (
+                <Box marginLeft={2}>
+                  <Button
+                    as="a"
+                    fontSize={1}
+                    href={currentFrameUrl}
+                    iconRight={LaunchIcon}
+                    mode="ghost"
+                    padding={2}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    text="Open story"
+                  />
+                </Box>
+              )}
               <Box marginLeft={2}>
                 <Button as="label" mode="bleed" padding={2}>
                   <Flex align="center">
@@ -186,6 +209,7 @@ export function WorkshopNavbar(props: {
       </Root>
     ),
     [
+      currentFrameUrl,
       handleHomeClick,
       handleToggleScheme,
       scheme,


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds a button in the workshop navbar that makes it possible to open a story in a new window. Sometimes it's nice, and necessary, to be able to work with a story outside of the workshop framework especially when it comes to responsive design.

<img width="653" alt="Screenshot 2022-02-04 at 11 46 06" src="https://user-images.githubusercontent.com/15094168/152516026-47c363b0-b8a4-4a04-b112-c1e46ac97858.png">


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
n/a

### Notes for release

Add button in the workshop navbar that makes it possible to open a story in a new window

<!--
A description of the change(s) that should be used in the release notes.
-->
