### PR TITLE
fix(ui): check if error.message is a string before rendering

### DIFF
--- a/packages/@sanity/ui/src/utils/errorBoundary.tsx
+++ b/packages/@sanity/ui/src/utils/errorBoundary.tsx
@@ -37,7 +37,9 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     const {error} = this.state
 
     if (error) {
-      return <Code>{error.message}</Code>
+      const message = typeof error?.message === 'string' ? error.message : 'Error'
+
+      return <Code>{message}</Code>
     }
 
     return this.props.children


### PR DESCRIPTION
### Description

Ran into a small bug with the error boundary.

If some component in the tree throws something and `error.message` is not a string, it ends up throwing again within the error boundary's render. ~I also changed the type of `error` to any in this case because it possible to throw non-errors and have them bubble here.~ I reverted that since it seemed to cause some type friction.

### What to review

Do the changes makes sense? Are the types correct?

### Notes for release

Fixes an issue where the `ErrorBoundary` itself could error if the `error.message` was not a string. 
