### PR TITLE
chore: mark packages as React 18-compatible

### DIFF
--- a/packages/@sanity/icons/package.json
+++ b/packages/@sanity/icons/package.json
@@ -38,7 +38,7 @@
     "react": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "^16.9 || ^17"
+    "react": "^16.9 || ^17 || ^18"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/logos/package.json
+++ b/packages/@sanity/logos/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@sanity/color": "^2.0",
-    "react": "^16.9 || ^17"
+    "react": "^16.9 || ^17 || ^18"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/ui/package.json
+++ b/packages/@sanity/ui/package.json
@@ -49,8 +49,8 @@
     "styled-components": "^5.3.5"
   },
   "peerDependencies": {
-    "react": "^16.9 || ^17",
-    "react-dom": "^16.9 || ^17",
+    "react": "^16.9 || ^17 || ^18",
+    "react-dom": "^16.9 || ^17 || ^18",
     "styled-components": "^5.2"
   },
   "repository": {


### PR DESCRIPTION
React 18 is out and we're already seeing support requests because of npms strict peer dependency handling. This PR upgrades the supported peer dependency range to include React 18, as all of the packages should be compatible with it.
