### PR TITLE
fix(ui): catch error when force updating tooltip popper

### DIFF
--- a/packages/@sanity/ui/src/primitives/tooltip/tooltip.tsx
+++ b/packages/@sanity/ui/src/primitives/tooltip/tooltip.tsx
@@ -118,7 +118,13 @@ export const Tooltip = forwardRef(function Tooltip(
   }, [isOpen, referenceElement])
 
   useEffect(() => {
-    if (forceUpdate) forceUpdate()
+    if (forceUpdate) {
+      try {
+        forceUpdate()
+      } catch (_) {
+        // ignore caught error
+      }
+    }
   }, [forceUpdate, content])
 
   // Close when `disabled` changes to `true`


### PR DESCRIPTION
### Description

Not quite sure _why_, but when using the tooltip inside of Sanity (on the publish button, specifically), it now crashes with an error: `flushSync() was called from inside a lifecycle method`. It might be that this forcing is no longer necessary due to upstream changes in popper.js, but I noticed that the popover component has a try/catch around the `forceUpdate()` call, and figured doing the same here would be acceptable for now - might warrant a deeper look at what is going on, but this unblocks us for now.

### What to review

- That the code change makes sense and does not have unintended side effects

### Notes for release

- Fixed an issue where the tooltip component might crash with a `flushSync()` error 
