### PR TITLE
fix: replace `ComponentType` with `ElementType`

### DIFF
--- a/apps/docs/components/article/articleContent/blocks/groqLogoGrid.tsx
+++ b/apps/docs/components/article/articleContent/blocks/groqLogoGrid.tsx
@@ -1,7 +1,7 @@
 import {GroqLogo, GroqMonogram} from '@sanity/logos'
 import {LogoGrid} from '../logoGrid'
 
-const logos: {component: React.ComponentType; name: string}[] = [
+const logos: {component: React.ElementType; name: string}[] = [
   {
     component: GroqLogo,
     name: 'GroqLogo',

--- a/apps/docs/components/article/articleContent/blocks/sanityLogoGrid.tsx
+++ b/apps/docs/components/article/articleContent/blocks/sanityLogoGrid.tsx
@@ -1,7 +1,7 @@
 import {SanityLogo, SanityMonogram} from '@sanity/logos'
 import {LogoGrid} from '../logoGrid'
 
-const logos: {component: React.ComponentType; name: string}[] = [
+const logos: {component: React.ElementType; name: string}[] = [
   {
     component: SanityLogo,
     name: 'SanityLogo',

--- a/apps/docs/components/article/articleContent/logoGrid/logoGrid.tsx
+++ b/apps/docs/components/article/articleContent/logoGrid/logoGrid.tsx
@@ -2,11 +2,7 @@ import {Box, Card, Code, Grid, Heading} from '@sanity/ui'
 import {createElement} from 'react'
 import {useApp} from '../../../app'
 
-export function LogoGrid({
-  logos,
-}: {
-  logos: {name: string; component: React.ComponentType<{dark?: boolean}>}[]
-}) {
+export function LogoGrid({logos}: {logos: {name: string; component: React.ElementType}[]}) {
   const app = useApp()
 
   return (

--- a/examples/studio/src/$sanity/dashboard/plugin.ts
+++ b/examples/studio/src/$sanity/dashboard/plugin.ts
@@ -2,7 +2,7 @@ import {DashboardIcon} from '@sanity/icons'
 import {DashboardTool} from './dashboardTool'
 
 export default (
-  params: {icon?: React.ComponentType | React.ReactNode; name?: string; title?: string} = {}
+  params: {icon?: React.ElementType | React.ReactNode; name?: string; title?: string} = {}
 ) => ({
   type: 'tool',
   name: params.name || 'dashboard',

--- a/packages/@sanity/ui-workshop/src/inspector/WorkshopInspector.tsx
+++ b/packages/@sanity/ui-workshop/src/inspector/WorkshopInspector.tsx
@@ -7,7 +7,7 @@ const MemoTab = memo(Tab)
 interface InspectorTab {
   id: string
   label: React.ReactNode
-  panel?: React.ComponentType
+  panel?: React.ElementType
   tone?: ButtonTone
 }
 
@@ -118,6 +118,6 @@ function InspectorTabView(props: {
   )
 }
 
-const MemoRender = memo(function MemoRender(props: {component: React.ComponentType}) {
+const MemoRender = memo(function MemoRender(props: {component: React.ElementType}) {
   return createElement(props.component)
 })

--- a/packages/@sanity/ui-workshop/src/plugins/perf/hooks/usePerfTest.tsx
+++ b/packages/@sanity/ui-workshop/src/plugins/perf/hooks/usePerfTest.tsx
@@ -6,7 +6,7 @@ import {usePerf} from './usePerf'
 /** @beta */
 export interface PerfTestHookProps<TargetType = unknown> {
   ref: React.MutableRefObject<TargetType | null>
-  Wrapper: React.ComponentType<{children?: React.ReactNode}>
+  Wrapper: React.ElementType<{children?: React.ReactNode}>
 }
 
 /** @beta */

--- a/packages/@sanity/ui-workshop/src/types/core.ts
+++ b/packages/@sanity/ui-workshop/src/types/core.ts
@@ -8,7 +8,7 @@ export interface WorkshopCollection {
 export interface WorkshopStory<Options = Record<string, unknown>> {
   name: string
   title: string
-  component: React.ComponentType
+  component: React.ElementType
   options?: Options
 }
 

--- a/packages/@sanity/ui-workshop/src/types/plugin.ts
+++ b/packages/@sanity/ui-workshop/src/types/plugin.ts
@@ -2,6 +2,6 @@
 export interface WorkshopPlugin {
   name: string
   title: string
-  inspector?: React.ComponentType
-  provider?: React.ComponentType<{children?: React.ReactNode}>
+  inspector?: React.ElementType
+  provider?: React.ElementType<{children?: React.ReactNode}>
 }

--- a/packages/@sanity/ui/src/components/autocomplete/autocomplete.tsx
+++ b/packages/@sanity/ui/src/components/autocomplete/autocomplete.tsx
@@ -32,7 +32,7 @@ export interface AutocompleteProps<Option extends BaseAutocompleteOption = BaseA
   customValidity?: string
   filterOption?: (query: string, option: Option) => boolean
   fontSize?: number | number[]
-  icon?: React.ComponentType | React.ReactNode
+  icon?: React.ElementType | React.ReactNode
   id: string
   /**
    * @beta

--- a/packages/@sanity/ui/src/components/menu/menuGroup.tsx
+++ b/packages/@sanity/ui/src/components/menu/menuGroup.tsx
@@ -14,7 +14,7 @@ import {useMenu} from './useMenu'
 export interface MenuGroupProps {
   as?: React.ElementType | keyof JSX.IntrinsicElements
   fontSize?: number | number[]
-  icon?: React.ComponentType | React.ReactNode
+  icon?: React.ElementType | React.ReactNode
   padding?: number | number[]
   popover?: Omit<PopoverProps, 'content' | 'open'>
   radius?: number | number[]

--- a/packages/@sanity/ui/src/components/menu/menuItem.tsx
+++ b/packages/@sanity/ui/src/components/menu/menuItem.tsx
@@ -23,8 +23,8 @@ export interface MenuItemProps extends ResponsivePaddingProps, ResponsiveRadiusP
   as?: React.ElementType | keyof JSX.IntrinsicElements
   fontSize?: number | number[]
   hotkeys?: string[]
-  icon?: React.ComponentType | React.ReactNode
-  iconRight?: React.ComponentType | React.ReactNode
+  icon?: React.ElementType | React.ReactNode
+  iconRight?: React.ElementType | React.ReactNode
   pressed?: boolean
   selected?: boolean
   space?: number | number[]

--- a/packages/@sanity/ui/src/components/tab/tab.tsx
+++ b/packages/@sanity/ui/src/components/tab/tab.tsx
@@ -12,7 +12,7 @@ export interface TabProps {
    */
   'aria-controls': string
   id: string
-  icon?: React.ComponentType | React.ReactNode
+  icon?: React.ElementType | React.ReactNode
   focused?: boolean
   fontSize?: number | number[]
   label?: React.ReactNode

--- a/packages/@sanity/ui/src/components/tree/treeItem.tsx
+++ b/packages/@sanity/ui/src/components/tree/treeItem.tsx
@@ -19,7 +19,7 @@ import {useTree} from './useTree'
 export interface TreeItemProps {
   expanded?: boolean
   fontSize?: number | number[]
-  icon?: React.ComponentType
+  icon?: React.ElementType
   padding?: number | number[]
   space?: number | number[]
   text?: React.ReactNode

--- a/packages/@sanity/ui/src/primitives/button/button.tsx
+++ b/packages/@sanity/ui/src/primitives/button/button.tsx
@@ -20,8 +20,8 @@ export interface ButtonProps extends ResponsivePaddingProps, ResponsiveRadiusPro
   as?: React.ElementType | keyof JSX.IntrinsicElements
   fontSize?: number | number[]
   mode?: ButtonMode
-  icon?: React.ComponentType | React.ReactNode
-  iconRight?: React.ComponentType | React.ReactNode
+  icon?: React.ElementType | React.ReactNode
+  iconRight?: React.ElementType | React.ReactNode
   justify?: FlexJustify | FlexJustify[]
   /**
    * @beta Do not use in production, as this might change.

--- a/packages/@sanity/ui/src/primitives/textInput/textInput.tsx
+++ b/packages/@sanity/ui/src/primitives/textInput/textInput.tsx
@@ -55,8 +55,8 @@ export interface TextInputProps {
   clearButton?: boolean | TextInputClearButtonProps
   customValidity?: string
   fontSize?: number | number[]
-  icon?: React.ComponentType | React.ReactNode
-  iconRight?: React.ComponentType | React.ReactNode
+  icon?: React.ElementType | React.ReactNode
+  iconRight?: React.ElementType | React.ReactNode
   /**
    * @beta
    */


### PR DESCRIPTION
### Description

Relates to  #990 and #3612. The `ComponentType` usage is blocking adoption of `@sanity/ui@next` on `react@18`. The reason is `ComponentType` is no longer assignable to `ReactNode`. The fix is to use `ElementType` instead.