### PR TITLE
Add 'color' type to TextInput component

### DIFF
--- a/packages/@sanity/ui/src/__workshop__/constants.ts
+++ b/packages/@sanity/ui/src/__workshop__/constants.ts
@@ -235,6 +235,7 @@ export const WORKSHOP_TEXT_INPUT_TYPE_OPTIONS: {[key: string]: TextInputType} = 
   time: 'time',
   text: 'text',
   week: 'week',
+  color: 'color',
 }
 
 export const WORKSHOP_TEXT_OVERFLOW_OPTIONS: {[key: string]: 'ellipsis' | ''} = {

--- a/packages/@sanity/ui/src/primitives/textInput/textInput.tsx
+++ b/packages/@sanity/ui/src/primitives/textInput/textInput.tsx
@@ -43,6 +43,7 @@ export type TextInputType =
   | 'time'
   | 'text'
   | 'week'
+  | 'color'
 
 /**
  * @public


### PR DESCRIPTION
### Description

Adds the ability to use the `color` type on a `TextInput` component, which allows for rendering of `<input type="color">` ([docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color)).

### What to review

Even though this is only a small TypeScript change, it's worth reviewing whether this type is desirable for the `TextInput` component. I think it is :)

The color input type can be tested in the Workshop under `Primitives > TextInput > Typed`. Alternatively, here is a slightly more elaborate example, using Sanity v3:

```typescript
import React, {ForwardedRef} from 'react'
import {PatchEvent, set} from 'sanity/form'
import {TextInput as _TextInput} from '@sanity/ui'
import {ObjectSchemaType} from '@sanity/types'
import debounce from 'lodash/debounce'
import styled from 'styled-components'

const TextInput = styled(_TextInput)`
    min-height: 2.2em;
`;

interface ColorInputProps {
    onChange: (patchEvent: PatchEvent) => void
    type: ObjectSchemaType
    value?: string
}

const ColorInput = React.forwardRef(
    (props: ColorInputProps, ref: ForwardedRef<HTMLInputElement>) => {
        const {onChange} = props

        const handleChange = React.useCallback(
            debounce(
                (inputValue?: string) => {
                    onChange(PatchEvent.from(set(inputValue)))
                },
                100,
                {leading: true, trailing: true}
            ),
            [onChange]
        )

        return (
            <TextInput
                ref={ref}
                value={props.value || '#000000'}
                type="color"
                clearButton
                onClear={() => handleChange()}
                onChange={(e) => handleChange(e.currentTarget.value)}
            />
        )
    }
)

export default ColorInput
```

This renders the following native, dependency-free color picker in Chrome on macOS, for example:
<img width="301" alt="Screen Shot 2022-09-14 at 11 46 29 AM" src="https://user-images.githubusercontent.com/425971/190028815-a41e5c05-71b0-4487-973c-8dc2a6f2afb9.png">

### Notes for release

N/A