### PR TITLE
fix: wrong file extension on main field

### DIFF
--- a/packages/@sanity/logos/package.json
+++ b/packages/@sanity/logos/package.json
@@ -5,7 +5,7 @@
   "source": "./src/index.ts",
   "module": "./dist/sanity-logos.js",
   "types": "./dist/types/src/index.d.ts",
-  "main": "./dist/sanity-logos.js",
+  "main": "./dist/sanity-logos.cjs",
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",


### PR DESCRIPTION
### Description

This is what's causing the `cannot use import statement outside a module` currently [happening on the react 18 branch](https://github.com/sanity-io/sanity/actions/runs/3056551512/jobs/4930830587).
