### PR TITLE
fix(ui): autocomplete infinite loop

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -46,7 +46,7 @@ jobs:
           CYPRESS_CACHE_FOLDER: './node_modules/.cypress'
         run: yarn test:browser
 
-      - name: Upload Cypress Videos
+      - name: Upload Cypress Artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -50,5 +50,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: cypress-videos
-          path: cypress/videos
+          name: cypress
+          path: |
+            cypress/screenshots
+            cypress/videos

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import {defineConfig} from 'cypress'
 
 export default defineConfig({
+  defaultCommandTimeout: 10000,
   e2e: {
     baseUrl: 'http://localhost:9009',
   },

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,6 @@
 import {defineConfig} from 'cypress'
 
 export default defineConfig({
-  defaultCommandTimeout: 10000,
   e2e: {
     baseUrl: 'http://localhost:9009',
   },

--- a/cypress/e2e/ui/autocomplete.cy.ts
+++ b/cypress/e2e/ui/autocomplete.cy.ts
@@ -38,7 +38,7 @@ context('Components/Autocomplete', () => {
     cy.get('#custom-listbox').realPress('ArrowDown')
 
     // Enter to select
-    cy.get('[data-qa="option-NO"]', {timeout: 10000}).should('have.focus').realPress('{enter}')
+    cy.get('[data-qa="option-NO"]').should('have.focus').realPress('{enter}')
 
     // Tab 1 time
     cy.get('#custom').should('have.focus').realPress('Tab')

--- a/cypress/e2e/ui/autocomplete.cy.ts
+++ b/cypress/e2e/ui/autocomplete.cy.ts
@@ -38,7 +38,7 @@ context('Components/Autocomplete', () => {
     cy.get('#custom-listbox').realPress('ArrowDown')
 
     // Enter to select
-    cy.get('[data-qa="option-NO"]').should('have.focus').realPress('{enter}')
+    cy.get('[data-qa="option-NO"]', {timeout: 10000}).should('have.focus').realPress('{enter}')
 
     // Tab 1 time
     cy.get('#custom').should('have.focus').realPress('Tab')

--- a/cypress/e2e/ui/autocomplete.cy.ts
+++ b/cypress/e2e/ui/autocomplete.cy.ts
@@ -38,7 +38,7 @@ context('Components/Autocomplete', () => {
     cy.get('#custom-listbox').realPress('ArrowDown')
 
     // Enter to select
-    cy.get('[data-qa="option-NO"]').should('have.focus').realPress('{enter}')
+    cy.get('[data-qa="option-NO"]', {timeout: 10000}).should('have.focus').realPress('{enter}')
 
     // Tab 1 time
     cy.get('#custom').should('have.focus').realPress('Tab')
@@ -111,7 +111,7 @@ context('Components/Autocomplete', () => {
     cy.get('#custom').click()
 
     // Search for "nor"
-    cy.get('#custom').type('nor')
+    cy.get('#custom', {timeout: 10000}).type('nor')
 
     // Arrow down 3 times
     cy.get('#custom-listbox').realPress('ArrowDown')

--- a/packages/@sanity/ui/src/components/autocomplete/autocomplete.tsx
+++ b/packages/@sanity/ui/src/components/autocomplete/autocomplete.tsx
@@ -2,6 +2,7 @@ import {ChevronDownIcon} from '@sanity/icons'
 import {
   cloneElement,
   forwardRef,
+  startTransition,
   useCallback,
   useEffect,
   useMemo,
@@ -233,13 +234,13 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
     if (listFocused !== listFocusedRef.current) {
       listFocusedRef.current = listFocused
 
-      dispatch({type: 'root/setListFocused', listFocused})
+      startTransition(() => dispatch({type: 'root/setListFocused', listFocused}))
     }
   }, [])
 
   const handleOptionSelect = useCallback(
     (v: string) => {
-      dispatch({type: 'value/change', value: v})
+      startTransition(() => dispatch({type: 'value/change', value: v}))
 
       popoverMouseWithinRef.current = false
 
@@ -366,7 +367,7 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
       valuePropRef.current = valueProp
 
       if (valueProp !== undefined) {
-        dispatch({type: 'value/change', value: valueProp})
+        startTransition(() => dispatch({type: 'value/change', value: valueProp}))
         valueRef.current = valueProp
       }
 
@@ -374,7 +375,7 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
     }
 
     if (valueProp !== value) {
-      dispatch({type: 'value/change', value: valueProp || null})
+      startTransition(() => dispatch({type: 'value/change', value: valueProp || null}))
     }
   }, [valueProp, value])
 

--- a/packages/@sanity/ui/src/components/autocomplete/autocomplete.tsx
+++ b/packages/@sanity/ui/src/components/autocomplete/autocomplete.tsx
@@ -251,7 +251,7 @@ const InnerAutocomplete = forwardRef(function InnerAutocomplete<
       if (onChange) onChange(v)
       if (onQueryChange) onQueryChange(null)
 
-      inputElementRef.current?.focus()
+      requestAnimationFrame(() => inputElementRef.current?.focus())
     },
     [onChange, onSelect, onQueryChange]
   )


### PR DESCRIPTION
### Description

By wrapping the dispatch call that happens during the `callback ref` in a `startTransition` it gets a slight debounce, just enough for it to no longer get caught inside an infinite render loop.
This is due to how callback refs almost cross over into the danger zone of Reacts "don't dispatch state setters during render"-rule. Anyhow, making it a transition solves that.
And it makes the autocomplete render yield to other updates on the page if things get really busy for react 🙂 